### PR TITLE
Added Docker support to project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/sdk:3.1-alpine AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY source/*.sln .
+COPY source/ark-metrics-exporter/*.csproj ./ark-metrics-exporter/
+RUN dotnet restore
+
+# copy everything else and build app
+COPY source/ark-metrics-exporter/* ./ark-metrics-exporter/
+WORKDIR /source/ark-metrics-exporter
+RUN dotnet publish -c release -o /app --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/runtime:3.1-alpine
+WORKDIR /app
+COPY --from=build /app ./
+COPY docker/config.yaml ./
+ENTRYPOINT ["dotnet", "ark-metrics-exporter.dll"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ servers:
     port: 5290
 ```
 
+Docker Image
+------------
+
+This application can be run as a docker container with the following configuration:
+```bash
+docker run -d -p 7777:7777 \
+    -v /path/to/config.yaml:/app/config.yaml \
+    gamecodeplus/ark-metrics-exporter
+```
+
 Notes
 -----
 Currently the application will not export the first set of results for approximately 30s after the application has started.  The metrics export page should exist at http://{ip address}:{prometheus-port}/metrics however the metrics data will not exist immediately as the servers are queried for the first time.

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -1,0 +1,4 @@
+prometheus-port: 7777
+servers:
+  - ip-address: "192.168.1.1"
+    port: 8815


### PR DESCRIPTION
This PR is adding Docker support for the project. One thing to note is that this is not adding any automation to build and push a docker image to dockerhub on commit to `main`. This would be a great addition to make. Another note is that I have not pushed a docker image to the "gamecodeplus" repository in Dockerhub, as I figured you would like to maintain that yourself. Until that is done, the image will not be pull-able as specified in the documentation.